### PR TITLE
Fix mobile interface issues

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -144,6 +144,12 @@
   height: 20px;
   max-height: 100px;
   overflow-y: auto;
+  font-size: 16px; /* Prevent zoom on iOS */
+}
+
+/* Prevent zoom on all input and textarea elements on mobile */
+input, textarea {
+  font-size: 16px;
 }
 
 .send-button {
@@ -235,5 +241,27 @@
   
   .message-item {
     max-width: 85%;
+  }
+  
+  .message-input-container {
+    flex-direction: column;
+    padding: 8px;
+  }
+  
+  /* Ensure reply preview doesn't interfere with input controls */
+  .message-input-container > div:first-child {
+    margin-bottom: 8px;
+  }
+  
+  /* Input row should remain horizontal even on mobile */
+  .message-input-container > div:last-child {
+    display: flex;
+    gap: 5px;
+    width: 100%;
+  }
+  
+  .message-input {
+    font-size: 16px; /* Prevent zoom on iOS */
+    margin-right: 0;
   }
 }


### PR DESCRIPTION
Fixes #5

- Add font-size: 16px to all input elements to prevent iOS Safari zoom on focus
- Improve mobile responsive layout for message input container
- Ensure reply preview doesn't push send button off screen on mobile

Generated with [Claude Code](https://claude.ai/code)